### PR TITLE
feat(llm_client): retrieve_batch_results_with_usage() for Anthropic batch token tracking

### DIFF
--- a/pipeline_a_scenarios/tests/test_batch_usage.py
+++ b/pipeline_a_scenarios/tests/test_batch_usage.py
@@ -1,0 +1,183 @@
+"""Unit tests for retrieve_batch_results_with_usage().
+
+Covers:
+- Mock-client short-circuit path returns the documented dict-of-dicts shape.
+- ValueError raised for non-Anthropic providers.
+- JSONL parsing extracts text + per-row input/output token counts for
+  succeeded rows, errored rows, and top-level error rows.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from pipeline_a_scenarios.utils.llm_client import BatchHandle, UnifiedLLMClient
+from pipeline_a_scenarios.tests.test_mock_clients import (
+    MockAnthropicClient,
+    MockOpenAIClient,
+)
+
+
+def _make_anthropic_client_stub(retrieve_fn):
+    """Build a minimal client object exposing client.messages.batches.retrieve."""
+    return SimpleNamespace(
+        messages=SimpleNamespace(batches=SimpleNamespace(retrieve=retrieve_fn))
+    )
+
+
+def test_mock_client_returns_dict_of_dicts():
+    client = UnifiedLLMClient(
+        provider="anthropic", client_override=MockAnthropicClient()
+    )
+    handle = BatchHandle(
+        provider="anthropic",
+        id="anth-batch-1",
+        metadata={"requests": [{"id": "req-1"}, {"id": "req-2"}]},
+    )
+
+    results = client.retrieve_batch_results_with_usage(handle)
+
+    assert set(results.keys()) == {"req-1", "req-2"}
+    for v in results.values():
+        assert set(v.keys()) == {"text", "input_tokens", "output_tokens"}
+        assert isinstance(v["text"], str)
+        assert isinstance(v["input_tokens"], int)
+        assert isinstance(v["output_tokens"], int)
+
+
+def test_non_anthropic_provider_raises():
+    client = UnifiedLLMClient(provider="openai", client_override=MockOpenAIClient())
+    handle = BatchHandle(
+        provider="openai", id="openai-batch-1", metadata={"requests": []}
+    )
+
+    with pytest.raises(ValueError, match="Anthropic-only"):
+        client.retrieve_batch_results_with_usage(handle)
+
+
+def test_jsonl_parsing_extracts_usage(monkeypatch):
+    """Direct test of retrieve_anthropic_batch_results_with_usage parsing.
+
+    The production path calls self.client.messages.batches.retrieve(batch_id)
+    and then requests.get(batch.results_url). We stub both.
+    """
+
+    class _Counts:
+        processing = 0
+        errored = 0
+        expired = 0
+
+    class _Batch:
+        request_counts = _Counts()
+        results_url = "https://example.invalid/results"
+
+    stub = _make_anthropic_client_stub(retrieve_fn=lambda batch_id: _Batch())
+    client = UnifiedLLMClient(provider="anthropic", client_override=stub)
+    client.api_key = "test-key"  # needed for the requests.get header
+
+    jsonl_lines = [
+        # Succeeded row with usage
+        json.dumps(
+            {
+                "custom_id": "req-success",
+                "result": {
+                    "type": "succeeded",
+                    "message": {
+                        "content": [{"type": "text", "text": "hello world"}],
+                        "usage": {"input_tokens": 1234, "output_tokens": 567},
+                    },
+                },
+            }
+        ),
+        # Errored row (per-request error)
+        json.dumps(
+            {
+                "custom_id": "req-errored",
+                "result": {
+                    "type": "errored",
+                    "error": {"message": "rate_limit"},
+                },
+            }
+        ),
+        # Top-level error row (no result key)
+        json.dumps(
+            {
+                "type": "error",
+                "request_id": "req-top-error",
+                "error": {"message": "auth"},
+            }
+        ),
+    ]
+
+    class _Response:
+        text = "\n".join(jsonl_lines)
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "pipeline_a_scenarios.utils.llm_client.requests.get",
+        lambda url, headers: _Response(),
+    )
+
+    results = client.retrieve_anthropic_batch_results_with_usage("anth-batch-1")
+
+    assert results["req-success"] == {
+        "text": "hello world",
+        "input_tokens": 1234,
+        "output_tokens": 567,
+    }
+    assert results["req-errored"]["text"].startswith("[ERROR]")
+    assert results["req-errored"]["input_tokens"] == 0
+    assert results["req-errored"]["output_tokens"] == 0
+    assert results["req-top-error"]["text"].startswith("[ERROR]")
+    assert results["req-top-error"]["input_tokens"] == 0
+    assert results["req-top-error"]["output_tokens"] == 0
+
+
+def test_succeeded_row_with_missing_usage_defaults_to_zero(monkeypatch):
+    """If Anthropic ever omits usage on a succeeded row, sum() must not crash."""
+
+    class _Counts:
+        processing = 0
+        errored = 0
+        expired = 0
+
+    class _Batch:
+        request_counts = _Counts()
+        results_url = "https://example.invalid/results"
+
+    stub = _make_anthropic_client_stub(retrieve_fn=lambda batch_id: _Batch())
+    client = UnifiedLLMClient(provider="anthropic", client_override=stub)
+    client.api_key = "test-key"
+
+    line = json.dumps(
+        {
+            "custom_id": "req-no-usage",
+            "result": {
+                "type": "succeeded",
+                "message": {
+                    "content": [{"type": "text", "text": "ok"}],
+                },
+            },
+        }
+    )
+
+    class _Response:
+        text = line
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "pipeline_a_scenarios.utils.llm_client.requests.get",
+        lambda url, headers: _Response(),
+    )
+
+    results = client.retrieve_anthropic_batch_results_with_usage("anth-batch-1")
+    assert results["req-no-usage"] == {
+        "text": "ok",
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }

--- a/pipeline_a_scenarios/utils/llm_client.py
+++ b/pipeline_a_scenarios/utils/llm_client.py
@@ -581,6 +581,105 @@ class UnifiedLLMClient:
 
         return results
 
+    def retrieve_batch_results_with_usage(
+        self, handle: BatchHandle, timeout: Optional[int] = None
+    ) -> Dict[str, Dict[str, Any]]:
+        """Anthropic-only variant of retrieve_batch_results that also returns
+        per-request token usage. Result shape:
+        {custom_id: {"text": str, "input_tokens": int, "output_tokens": int}}.
+
+        Error/unknown rows return zero token counts so callers can safely sum.
+        Non-Anthropic providers raise ValueError until added on demand.
+        """
+        if handle.provider != "anthropic":
+            raise ValueError(
+                "retrieve_batch_results_with_usage is Anthropic-only; "
+                f"got provider={handle.provider}"
+            )
+
+        if self._is_mock_client():
+            return {
+                r["id"]: {
+                    "text": f"{self.provider} mock batch",
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                }
+                for r in handle.metadata.get("requests", [])
+            }
+
+        timeout = timeout or 1800
+        return self.retrieve_anthropic_batch_results_with_usage(handle.id, timeout)
+
+    def retrieve_anthropic_batch_results_with_usage(
+        self, batch_id: str, timeout: int = 1800
+    ) -> Dict[str, Dict[str, Any]]:
+        batch = self._poll_until(
+            fn=lambda: self.client.messages.batches.retrieve(batch_id),
+            is_done=lambda b: b.request_counts.processing == 0,
+            interval=10,
+            timeout=timeout,
+        )
+
+        if batch.request_counts.errored > 0 or batch.request_counts.expired > 0:
+            raise RuntimeError("Anthropic batch failed")
+
+        response = requests.get(
+            batch.results_url,
+            headers={"x-api-key": self.api_key, "anthropic-version": "2023-06-01"},
+        )
+        response.raise_for_status()
+
+        results: Dict[str, Dict[str, Any]] = {}
+        for line in response.text.splitlines():
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+
+            if "type" in obj and obj["type"] == "error" and "result" not in obj:
+                results[obj.get("request_id", "unknown")] = {
+                    "text": f"[ERROR] {obj.get('error', {}).get('message', 'Unknown error')}",
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                }
+                continue
+
+            if "result" not in obj:
+                raise ValueError(f"Unexpected batch response format: {obj}")
+
+            result = obj["result"]
+            custom_id = obj.get("custom_id", "unknown")
+
+            if result["type"] == "succeeded":
+                message = result.get("message", {}) or {}
+                text = next(
+                    (
+                        block.get("text", "")
+                        for block in message.get("content", [])
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ),
+                    "",
+                )
+                usage = message.get("usage", {}) or {}
+                results[custom_id] = {
+                    "text": text,
+                    "input_tokens": int(usage.get("input_tokens", 0) or 0),
+                    "output_tokens": int(usage.get("output_tokens", 0) or 0),
+                }
+            elif result["type"] == "errored":
+                results[custom_id] = {
+                    "text": f"[ERROR] {result.get('error', {}).get('message', 'Unknown error')}",
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                }
+            else:
+                results[custom_id] = {
+                    "text": f"[UNKNOWN] Result type: {result.get('type')}",
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                }
+
+        return results
+
     def retrieve_openai_batch_results(
         self, batch_id: str, timeout: int = 1800
     ) -> Dict[str, str]:


### PR DESCRIPTION
Closes #53. Unblocks remaining item 3 on PR #41.

## What

Adds `UnifiedLLMClient.retrieve_batch_results_with_usage(handle, timeout=None)`. Returns `Dict[str, dict]`:

```python
{custom_id: {"text": str, "input_tokens": int, "output_tokens": int}}
```

Error rows carry zero token counts so callers can safely `sum()`. Non-Anthropic providers raise `ValueError`.

## Why

`generate_scenarios.py` (PR #41) logs `input_tokens=0, output_tokens=0` to `cost_tracker.log_cost()` because the current `retrieve_batch_results()` returns `Dict[str, str]` and discards the `usage` payload from the batch JSONL. PIPE-A3's <\$100 budget gate is silently a no-op as a result.

## Why a new method (not widening the existing return type)

Modifying `retrieve_batch_results()` would break:
- `analyze_batch_results.py:55-73` — production caller passes the value to `parse_response()` as a string.
- `tests/test_llm_client.py:339-341` — asserts `isinstance(content, str)`.
- 4 mock-test return-value fixtures + `MockBatchClient` short-circuit.

This PR leaves all of that untouched. Existing consumers see no diff in shape or behavior. The only consumer that needs the rich return is the one that explicitly opts into the new method.

## Tests

`pipeline_a_scenarios/tests/test_batch_usage.py` — 4 unit tests:

- `test_mock_client_returns_dict_of_dicts` — mock-client short-circuit returns the documented shape
- `test_non_anthropic_provider_raises` — ValueError for OpenAI/Gemini
- `test_jsonl_parsing_extracts_usage` — succeeded + errored + top-level-error rows, monkeypatched `requests.get` and `messages.batches.retrieve`
- `test_succeeded_row_with_missing_usage_defaults_to_zero` — defensive fallback if Anthropic omits `usage`

Full `pipeline_a_scenarios/tests/test_*batch*.py` + `test_result_analysis.py` + `test_phase2_batch.py` + new file → 80/80 pass. Pre-existing failures in `tests/unit/test_llm_client.py` (`get_tracker` mock + `test_batch_operations` metadata) confirmed identical on `main` — not caused by this PR.

## Consumer pattern for PR #41

```python
results_with_usage = client.retrieve_batch_results_with_usage(handle)
results = {cid: r["text"] for cid, r in results_with_usage.items()}  # downstream unchanged
in_tok  = sum(r["input_tokens"]  for r in results_with_usage.values())
out_tok = sum(r["output_tokens"] for r in results_with_usage.values())
cost_tracker.log_cost(provider="anthropic", model=model, input_tokens=in_tok, output_tokens=out_tok)
```